### PR TITLE
Update acceptance.js

### DIFF
--- a/src/acceptance.js
+++ b/src/acceptance.js
@@ -76,12 +76,12 @@
             var url = [
                 'https://',
                 config.baseUrl,
-                '?apn=' + config.apn,
+		'?link=' +
+                encodeURIComponent('https://' + config.env + '://qr/' + shortlinkUrl),
+                '&apn=' + config.apn,
                 '&ibi=' + config.ibi,
                 '&isi=' + config.isi,
                 '&ius=eu.settle.app.firebaselink',
-                '&link=' +
-                encodeURIComponent('https://' + config.env + '://qr/' + shortlinkUrl),
             ].join('');
 
             exports.redirect_to(url);


### PR DESCRIPTION
Due to changes in iOS, the ordering of the parameters seems important, with `link` needed first.